### PR TITLE
Hook::register has changed API

### DIFF
--- a/piwik/piwik.php
+++ b/piwik/piwik.php
@@ -50,7 +50,7 @@ function piwik_load_config(App $a, ConfigFileLoader $loader)
 	$a->getConfigCache()->load($loader->loadAddonConfig('piwik'));
 }
 
-function piwik_analytics(App $a, array &$b)
+function piwik_analytics(App $a, string &$b)
 {
 	/*
 	 *   styling of every HTML block added by this addon is done in the


### PR DESCRIPTION
`Hook::register` now takes a string as the second parameter, not an array. Without this change Friendica fails to start, with errors such as:
```
2022-11-07T11:40:20Z index [ERROR]: Uncaught Exception TypeError: "Argument 2 passed to piwik_analytics() must be of the type array, string given, called in /var/www/html/src/Core/Hook.php on line 223" at /var/www/html/addon/piwik/piwik.php line 53 {"exception":"TypeError: Argument 2 passed to piwik_analytics() must be of the type array, string given, called in /var/www/html/src/Core/Hook.php on line 223 and defined in /var/www/html/addon/piwik/piwik.php:53\nStack trace:\n#0 /var/www/html/src/Core/Hook.php(223): piwik_analytics(Object(Friendica\\App), '<h1><img width=...')\n#1 /var/www/html/src/Core/Hook.php(198): Friendica\\Core\\Hook::callSingle(Object(Friendica\\App), 'page_end', Array, '<h1><img width=...')\n#2 /var/www/html/src/App/Page.php(493): Friendica\\Core\\Hook::callAll('page_end', '<h1><img width=...')\n#3 /var/www/html/src/App.php(722): Friendica\\App\\Page->run(Object(Friendica\\App), Object(Friendica\\App\\BaseURL), Object(Friendica\\App\\Arguments), Object(Friendica\\App\\Mode), Object(GuzzleHttp\\Psr7\\Response), Object(Friendica\\Core\\L10n), Object(Friendica\\Util\\Profiler), Object(Friendica\\Core\\Config\\Type\\JitConfig), Object(Friendica\\Core\\PConfig\\Type\\JitPConfig))\n#4 /var/www/html/index.php(44): Friendica\\App->runFrontend(Object(Friendica\\App\\Router), Object(Friendica\\Core\\PConfig\\Type\\JitPConfig), Object(Friendica\\Security\\Authentication), Object(Friendica\\App\\Page), Object(Friendica\\Util\\HTTPInputData), 1667821218.5153)\n#5 {main}"} - {"file":null,"line":null,"function":null,"uid":"73d499","process_id":52}
```